### PR TITLE
Initial ARIA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Features
     This manifests itself not only in clear and thorough developer
     documentation (below), but also verbose documentation within the code
     itself.
+*   **ARIA Support (in progress).** Support for
+    [WAI-ARIA](http://www.w3.org/TR/wai-aria/) to provide make the plugin
+    as accessible as possible.
 
 Requirements
 ------------
@@ -234,6 +237,15 @@ be used).
     item were selected from the results list.
 
     _Default:_ null
+
+    ---------------------------------------------------------------------------
+*   **selectedOptionClass** _string, 'selected'_
+
+    The public-facing class to apply to selected items in the list. You are
+    encouraged to style and script off this class, rather than the
+    internal _mp_highlighted_ class.
+
+    _Default:_ 'selected'
 
     ---------------------------------------------------------------------------
 *   **url** _string, null_

--- a/src/jquery.marcopolo.js
+++ b/src/jquery.marcopolo.js
@@ -130,8 +130,7 @@
       var self = this;
 
       // Create a more appropriately named alias for the input.
-      self.$input = self.element.attr({
-          'class'             : 'mp_input',
+      self.$input = self.element.addClass('mp_input').attr({
           'aria-autocomplete' : 'list'
         });
 
@@ -141,7 +140,7 @@
                      .hide()
                      .insertAfter(self.$input);
 
-      // Add an accessible required attribute if the input value is required.
+      // Add an accessible required attribute if a list value is required.
       if (self.options.required === true)
         self.$list.attr('aria-required', 'true');
 
@@ -302,7 +301,7 @@
         self.$input.removeAttr('autocomplete');
       }
 
-      self.$input.removeClass('mp_input').removeAttr('aria-expanded').removeAttr('aria-autocomplete');
+      self.$input.removeClass('mp_input').removeAttr('aria-autocomplete');
 
       if (options.label) {
         options.label.removeClass('mp_label');


### PR DESCRIPTION
Added initial [ARIA](http://www.w3.org/TR/wai-aria/) support to marcopolo.

TAB (and SHIFT+TAB), HOME and END key bindings.
Roles and attributes to indicate semantics.

There are still a couple things missing that would provide full aria support. They depend on being able to uniquely identify the listbox and options. What would be needed is a UID for the current instance of marcopolo that can then be used to keep IDs unique.

The input should technically have `role=combobox aria-owns=LISTBOX_ID`. I'll gladly implement these further features, if you could implement a UID system to keep the IDs unique even if there are multiple marcopolo's on the page. (I don't feel I have the chops to build that from scratch.)

_I didn't commit a minified version, since I didn't know your procedure for this. If you explain it to me, I'd be glad to that for future pull requests_
