### PR TITLE
Custom classes and ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ be used).
     _Default:_ 250
 
     ---------------------------------------------------------------------------
+*   **errorClass** _string_
+
+    The class to apply to the <li> when an error occurs.
+
+    _Default:_ 'error'
+
+    ---------------------------------------------------------------------------
 *   **hideOnSelect** _boolean_
 
     Whether to hide the results list when an item is selected. Interesting
@@ -192,6 +199,20 @@ be used).
     _Default:_ null
 
     ---------------------------------------------------------------------------
+*   **listboxClass** _string_
+
+    A custom class to apply to the listbox.
+
+    _Default:_ null
+
+    ---------------------------------------------------------------------------
+*   **listboxId** _string_
+
+    A custom id to apply to the listbox.
+
+    _Default:_ null
+
+    ---------------------------------------------------------------------------
 *   **minChars** _integer_
 
     The minimum number of characters required before a request is fired. See
@@ -199,6 +220,21 @@ be used).
     when this value is not reached.
 
     _Default:_ 1
+
+    ---------------------------------------------------------------------------
+*   **minCharsClass** _string_
+
+    The class to apply to the <li> when the user hasn't typed the minimum
+    amount of characters into the input.
+
+    _Default:_ 'min_chars'
+
+    ---------------------------------------------------------------------------
+*   **noResultsClass** _string_
+
+    The class to apply to the <li> when the query returned no results.
+
+    _Default:_ 'no_results'
 
     ---------------------------------------------------------------------------
 *   **param** _string_
@@ -226,6 +262,13 @@ be used).
     _mp\_selectable_.
 
     _Default:_ *
+
+    ---------------------------------------------------------------------------
+*   **selectableOptionClass** _string_
+
+    The class to apply to selectable options.
+
+    _Default:_ 'selectable'
 
     ---------------------------------------------------------------------------
 *   **selected** _object, null_

--- a/src/jquery.marcopolo.js
+++ b/src/jquery.marcopolo.js
@@ -117,7 +117,7 @@
       // Custom classes to add to the selectable options. This makes it easy
       // to decouple your own styles and scripts from marcopolo, so you don't
       // need to select off of '.mp_selectable'.
-      selectableOptionClass: null,
+      selectableOptionClass: 'selectable',
       // Prime the input with a selected item.
       selected: null,
       // The URL to GET request for the results.
@@ -713,7 +713,7 @@
       // Mark all selectable items, based on the 'selectable' selector setting.
       $list
         .children(options.selectable)
-        .addClass('mp_selectable ' + (options.selectableOptionClass || ''));
+        .addClass('mp_selectable ' + options.selectableOptionClass);
 
       self._trigger('results', [data]);
 


### PR DESCRIPTION
Added the ability to pass in custom classes and ids when initializing the plugin. This way people aren't tied to selecting off of the `mp_` prefixed classes. The way I see it, those should be internal classes only, and the user should be able to choose their own. That way their code can be decoupled from the plugin.

I realized it also might make switching from other plugins slightly easier, as you could make the custom class `ui_menu_item` say instead of rewriting styles. (Can't remember if that's actually what jQueryUI's is, but you get the idea.)

Also thinking about adding the option to pass in a selector to a listbox that is already in the DOM. That way people aren't forced to have the listbox right after the input in the dom. (the aria-owns property, and UIDs, would be even more necessary then) What do you think?
