### PR TITLE
IE7/8 bug

### DIFF
--- a/src/jquery.marcopolo.js
+++ b/src/jquery.marcopolo.js
@@ -1039,7 +1039,7 @@
 
       self.element.trigger(triggerName, args);
 
-      return callback && callback.apply(self.element, args);
+      return callback && callback.apply(self.element, args || []);
     }
   });
 }));


### PR DESCRIPTION
Hey Justin,

I ran into a bug in IE8 (and IE8 in IE7 mode) that prevented MarcoPolo from showing any results. If debugging is on, it throws a bunch of "Object requested" errors. This seems to affect your demo page as well.

Changing just this instance in the _trigger function seemed to have fixed the issue for me, so I don't know if the numerous other calls to .apply(...) are affected by this issue yet.

Thanks,
Vlad
