### PR TITLE
Fix for IE8 (Source only)

### DIFF
--- a/src/jquery.marcopolo.js
+++ b/src/jquery.marcopolo.js
@@ -956,7 +956,7 @@
         data = options.formatData.call($input, data);
       }
 
-      if ($.isEmptyObject(data)) {
+      if ($.isEmptyObject(data) || data.length === 0) {
         self._buildNoResultsList(q);
       }
       else {


### PR DESCRIPTION
Sorry, I wasn't able to compile it due to jasmine complaining about some errors. But this fixes it for IE8, in fact I believe using `.length` is better than `isEmptyObject`, less error-prone. You are returning an empty array anyway. 
