### PR TITLE
Allow options.data to accept a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ be used).
     _Default:_ false
 
     ----------------------------------------------------------------------------
-*   **data** _object, string_
+*   **data** _object, string, function_
 
     Additional data to be sent in the request query string. (Note: The query
     string parameter that is set with the input value (_param_ option) will
@@ -187,6 +187,18 @@ be used).
     exists.)
 
     _Default:_ {}
+
+    When a function is provided it is evaluated for every request, thus allows
+    to provide dynamic additional query arguments. The provided function must
+    return an _object_.
+
+    _Parameters:_
+
+    *   **q** _string_ Requested input value.
+
+    _this:_ _jQuery object_ Text input (no need to wrap like _$(this)_).
+
+    _Return:_ _object_ to use as the additional data to be sent in the query.
 
     ----------------------------------------------------------------------------
 *   **delay** _integer_

--- a/src/jquery.marcopolo.js
+++ b/src/jquery.marcopolo.js
@@ -1079,6 +1079,7 @@
       self.timer = setTimeout(function () {
         var param = {},
             params = {},
+            otherParams = {},
             cacheKey,
             $inputParent = $();
 
@@ -1092,7 +1093,11 @@
         // Add the query to the additional data to be sent with the request.
         param[options.param] = q;
 
-        params = $.extend({}, options.data, param);
+        // Extract additional params from options.data, if possible as function.
+        otherParams = $.isFunction(options.data) ? options.data.call($input, q) : options.data;
+
+        // Merge all parameters together
+        params = $.extend({}, otherParams, param);
 
         // Build the request URL with query string data to use as the cache
         // key.


### PR DESCRIPTION
Thanks for this awesome plugin, it really has simplified building autocompletes in a quite few of projects for me.

Sometimes it's required to provide dynamic data, like excluding items or similar things. The current solution is to manually update the `data` option after an item has been selected or a similar change:

``` javascript
  $input.marcoPolo('option', 'data', { without: selected.join(',') })
```

To simplify providing this, this PR adds all necessary changes to allow options.data to accept a function, so this could be rewritten as:

``` javascript
  $input.marcoPolo({
    url: '/marco/polo',
    data: function($inp, query) {
      return { without: selected.join(',') };
    }, ...
  });
```

Of course the existing functionality by providing just an object or string still works as expected.

PS: I only commited the changed source file, but the build works fine and I'm actually already using my custom build in a project.
