### PR TITLE
Fixes an issue with Chrome

### DIFF
--- a/src/jquery.marcopolo.js
+++ b/src/jquery.marcopolo.js
@@ -317,7 +317,9 @@
         return;
       }
 
-      self.$input.val(q);
+      if (q !== self.$input.val()) {
+        self.$input.val(q);
+      }
 
       // Reset the currently selected data.
       self.selectedData = null;


### PR DESCRIPTION
In Chrome, if you enter text and then move the cursor to the front of an input and continue typing, the cursor will automatically move to the end of the input after entering the first character.

For example:
If I type `test` into the input, and then attempt to rectify the text by typing `some test`. The cursor for the input will move as soon as I type `s`, resulting in `stestome`

This makes the input almost unusable for editing when using Chrome
